### PR TITLE
build: add dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+models/
+decensor_input/
+decensor_output/

--- a/Dockerfile-py3
+++ b/Dockerfile-py3
@@ -1,0 +1,12 @@
+FROM tensorflow/tensorflow:latest-py3
+
+RUN apt update && apt install -y python3 python3-pip python3-tk python3-numpy && apt clean
+
+WORKDIR /app
+COPY . /app
+
+RUN pip --no-cache-dir install --upgrade pip setuptools
+RUN pip --no-cache-dir install wheel
+RUN pip --no-cache-dir install -r requirements.txt
+
+CMD ["python3", "decensor.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Pillow
+tqdm
+scipy
+pyamg
+matplotlib


### PR DESCRIPTION
We add a Python 3 Dockerfile. Example usage:

```bash
docker build -t dmb . && docker run dmb
docker cp $(docker ps -alq):/app/decensor_output/ ./
```

In addition we add `requirements.txt` and `.gitignore` files for
convenience.

Closes: https://github.com/deeppomf/DeepMindBreak/issues/6
Closes: https://github.com/deeppomf/DeepMindBreak/issues/7